### PR TITLE
Add modular admin dashboard with dummy sign-in

### DIFF
--- a/app/admin/[module]/new/page.tsx
+++ b/app/admin/[module]/new/page.tsx
@@ -1,0 +1,18 @@
+import { getModule } from "../../modules";
+import { notFound } from "next/navigation";
+
+export default function NewModulePage({
+  params,
+}: {
+  params: { module: string };
+}) {
+  const mod = getModule(params.module);
+  if (!mod) notFound();
+  return (
+    <div className="p-8 space-y-2">
+      <h1 className="text-2xl font-bold">Create {mod.title}</h1>
+      <p>{mod.title} creation form coming soon.</p>
+    </div>
+  );
+}
+

--- a/app/admin/[module]/new/page.tsx
+++ b/app/admin/[module]/new/page.tsx
@@ -1,12 +1,13 @@
 import { getModule } from "../../modules";
 import { notFound } from "next/navigation";
 
-export default function NewModulePage({
+export default async function NewModulePage({
   params,
 }: {
-  params: { module: string };
+  params: Promise<{ module: string }>;
 }) {
-  const mod = getModule(params.module);
+  const { module } = await params;
+  const mod = getModule(module);
   if (!mod) notFound();
   return (
     <div className="p-8 space-y-2">

--- a/app/admin/[module]/page.tsx
+++ b/app/admin/[module]/page.tsx
@@ -1,0 +1,18 @@
+import { getModule } from "../modules";
+import { notFound } from "next/navigation";
+
+export default function ModulePage({
+  params,
+}: {
+  params: { module: string };
+}) {
+  const mod = getModule(params.module);
+  if (!mod) notFound();
+  return (
+    <div className="p-8 space-y-2">
+      <h1 className="text-2xl font-bold">{mod.title}</h1>
+      <p>View and create {mod.title.toLowerCase()} coming soon.</p>
+    </div>
+  );
+}
+

--- a/app/admin/[module]/page.tsx
+++ b/app/admin/[module]/page.tsx
@@ -1,12 +1,13 @@
 import { getModule } from "../modules";
 import { notFound } from "next/navigation";
 
-export default function ModulePage({
+export default async function ModulePage({
   params,
 }: {
-  params: { module: string };
+  params: Promise<{ module: string }>;
 }) {
-  const mod = getModule(params.module);
+  const { module } = await params;
+  const mod = getModule(module);
   if (!mod) notFound();
   return (
     <div className="p-8 space-y-2">

--- a/app/admin/components/ModuleCard.tsx
+++ b/app/admin/components/ModuleCard.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+import type { AdminModule } from "../modules";
+
+type ModuleCardProps = AdminModule;
+
+export function ModuleCard({ slug, title }: ModuleCardProps) {
+  return (
+    <div className="border p-4 rounded shadow-sm">
+      <h2 className="text-lg font-semibold mb-2">{title}</h2>
+      <div className="flex gap-4">
+        <Link href={`/admin/${slug}`} className="text-blue-600 underline">
+          View
+        </Link>
+        <Link href={`/admin/${slug}/new`} className="text-blue-600 underline">
+          Create
+        </Link>
+      </div>
+    </div>
+  );
+}
+

--- a/app/admin/modules.ts
+++ b/app/admin/modules.ts
@@ -1,0 +1,16 @@
+export interface AdminModule {
+  slug: string;
+  title: string;
+}
+
+export const adminModules: AdminModule[] = [
+  { slug: "work-orders", title: "Work Orders" },
+  { slug: "preventive-maintenance", title: "Preventative Maintenance" },
+  { slug: "employees", title: "Employees & Roles" },
+  { slug: "equipment", title: "Equipment" },
+  { slug: "templates", title: "Work Order Templates" },
+];
+
+export const getModule = (slug: string): AdminModule | undefined =>
+  adminModules.find((m) => m.slug === slug);
+

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,16 @@
+import { adminModules } from "./modules";
+import { ModuleCard } from "./components/ModuleCard";
+
+export default function AdminDashboard() {
+  return (
+    <div className="p-8 space-y-6">
+      <h1 className="text-3xl font-bold">Admin Dashboard</h1>
+      <div className="grid gap-6 md:grid-cols-2">
+        {adminModules.map((m) => (
+          <ModuleCard key={m.slug} {...m} />
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,103 +1,48 @@
-import Image from "next/image";
+"use client";
 
-export default function Home() {
+import { useRouter } from "next/navigation";
+import { useState, FormEvent } from "react";
+
+export default function SignInPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    // Dummy sign in just redirects to the admin dashboard
+    router.push("/admin");
+  };
+
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
+    <div className="min-h-screen flex items-center justify-center">
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col gap-4 p-6 bg-white rounded shadow-md w-full max-w-sm"
+      >
+        <h1 className="text-2xl font-bold text-center">Sign In</h1>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="border p-2 rounded"
         />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2 rounded"
+        />
+        <button
+          type="submit"
+          className="bg-blue-600 text-white py-2 rounded hover:bg-blue-700"
         >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+          Sign In
+        </button>
+      </form>
     </div>
   );
 }
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev -H 0.0.0.0",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
     "test": "echo \"No tests\""


### PR DESCRIPTION
## Summary
- replace landing page with a dummy sign-in form that forwards to the admin dashboard
- add modular admin dashboard with cards for work orders, maintenance, employees, equipment and templates
- stub view and creation pages for each admin module

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68988eef84688323ab9a11628580fb0f