### PR TITLE
feat: add work order creation page and API listing

### DIFF
--- a/app/admin/work-orders/new/page.tsx
+++ b/app/admin/work-orders/new/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../../work-orders/new/page';

--- a/app/admin/work-orders/new/page.tsx
+++ b/app/admin/work-orders/new/page.tsx
@@ -1,1 +1,3 @@
-export { default } from '../../../work-orders/new/page';
+import CreateWorkOrderPage from '../../../work-orders/new/page';
+
+export default CreateWorkOrderPage;

--- a/app/admin/work-orders/page.tsx
+++ b/app/admin/work-orders/page.tsx
@@ -1,1 +1,3 @@
-export { default } from '../../work-orders/page';
+import WorkOrdersPage from '../../work-orders/page';
+
+export default WorkOrdersPage;

--- a/app/admin/work-orders/page.tsx
+++ b/app/admin/work-orders/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../work-orders/page';

--- a/app/api/work-order-templates/route.ts
+++ b/app/api/work-order-templates/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+
+interface WorkOrderTemplate {
+  id: number;
+  name: string;
+  fields: {
+    siteId?: number;
+    title?: string;
+    descriptionMd?: string;
+    assetId?: number;
+    priority?: 'P0' | 'P1' | 'P2' | 'P3' | 'P4';
+  };
+}
+
+const templates: WorkOrderTemplate[] = [
+  { id: 0, name: 'Blank', fields: {} },
+  {
+    id: 1,
+    name: 'Routine Inspection',
+    fields: {
+      title: 'Routine Inspection',
+      descriptionMd: 'Inspect equipment and report issues.',
+      priority: 'P3',
+    },
+  },
+];
+
+export async function GET() {
+  return NextResponse.json(templates);
+}
+

--- a/app/api/work-orders/route.ts
+++ b/app/api/work-orders/route.ts
@@ -11,6 +11,18 @@ const schema = z.object({
   priority: z.enum(['P0', 'P1', 'P2', 'P3', 'P4']).default('P3'),
 });
 
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const siteId = searchParams.get('siteId');
+  const where = siteId ? { siteId: Number(siteId) } : undefined;
+  const workOrders = await prisma.workOrder.findMany({
+    where,
+    orderBy: { id: 'desc' },
+    take: 100,
+  });
+  return NextResponse.json(workOrders);
+}
+
 export async function POST(req: NextRequest) {
   let body: unknown;
   try {

--- a/app/api/work-orders/route.ts
+++ b/app/api/work-orders/route.ts
@@ -7,7 +7,7 @@ const schema = z.object({
   siteId: z.number(),
   title: z.string().min(3),
   descriptionMd: z.string().optional(),
-  assetId: z.number().optional(),
+  assetId: z.number().int().positive().optional(),
   priority: z.enum(['P0', 'P1', 'P2', 'P3', 'P4']).default('P3'),
 });
 
@@ -43,6 +43,13 @@ export async function POST(req: NextRequest) {
   const site = await prisma.site.findUnique({ where: { id: data.siteId } });
   if (!site) {
     return NextResponse.json({ error: 'Site not found' }, { status: 404 });
+  }
+
+  if (data.assetId) {
+    const asset = await prisma.asset.findUnique({ where: { id: data.assetId } });
+    if (!asset) {
+      return NextResponse.json({ error: 'Asset not found' }, { status: 404 });
+    }
   }
 
   const year = new Date().getFullYear();

--- a/app/work-orders/new/page.tsx
+++ b/app/work-orders/new/page.tsx
@@ -1,6 +1,18 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+
+interface Template {
+  id: number;
+  name: string;
+  fields: {
+    siteId?: number;
+    title?: string;
+    descriptionMd?: string;
+    assetId?: number;
+    priority?: 'P0' | 'P1' | 'P2' | 'P3' | 'P4';
+  };
+}
 
 export default function CreateWorkOrderPage() {
   const [siteId, setSiteId] = useState('1');
@@ -9,6 +21,25 @@ export default function CreateWorkOrderPage() {
   const [priority, setPriority] = useState('P3');
   const [assetId, setAssetId] = useState('');
   const [saving, setSaving] = useState(false);
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [templateId, setTemplateId] = useState(0);
+
+  useEffect(() => {
+    fetch('/api/work-order-templates')
+      .then((res) => res.json())
+      .then((data) => setTemplates(data));
+  }, []);
+
+  useEffect(() => {
+    const tmpl = templates.find((t) => t.id === templateId);
+    if (tmpl) {
+      setSiteId(tmpl.fields.siteId ? String(tmpl.fields.siteId) : '1');
+      setTitle(tmpl.fields.title ?? '');
+      setDesc(tmpl.fields.descriptionMd ?? '');
+      setPriority(tmpl.fields.priority ?? 'P3');
+      setAssetId(tmpl.fields.assetId ? String(tmpl.fields.assetId) : '');
+    }
+  }, [templateId, templates]);
 
   async function save() {
     setSaving(true);
@@ -38,6 +69,19 @@ export default function CreateWorkOrderPage() {
   return (
     <div className="max-w-md mx-auto p-4 space-y-3">
       <h1 className="text-xl font-semibold">Create Work Order</h1>
+      {templates.length > 0 && (
+        <select
+          className="w-full border rounded p-2"
+          value={templateId}
+          onChange={(e) => setTemplateId(Number(e.target.value))}
+        >
+          {templates.map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.name}
+            </option>
+          ))}
+        </select>
+      )}
       <input
         className="w-full border rounded p-2"
         placeholder="Site ID"

--- a/app/work-orders/new/page.tsx
+++ b/app/work-orders/new/page.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function CreateWorkOrderPage() {
+  const [siteId, setSiteId] = useState('1');
+  const [title, setTitle] = useState('');
+  const [desc, setDesc] = useState('');
+  const [priority, setPriority] = useState('P3');
+  const [assetId, setAssetId] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  async function save() {
+    setSaving(true);
+    try {
+      const res = await fetch('/api/work-orders', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          siteId: Number(siteId),
+          title,
+          descriptionMd: desc,
+          priority,
+          assetId: assetId ? Number(assetId) : undefined,
+        }),
+      });
+      if (!res.ok) throw new Error('Failed');
+      setTitle('');
+      setDesc('');
+      setPriority('P3');
+      setAssetId('');
+      alert('Work order created');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="max-w-md mx-auto p-4 space-y-3">
+      <h1 className="text-xl font-semibold">Create Work Order</h1>
+      <input
+        className="w-full border rounded p-2"
+        placeholder="Site ID"
+        value={siteId}
+        onChange={(e) => setSiteId(e.target.value)}
+      />
+      <input
+        className="w-full border rounded p-2"
+        placeholder="Title"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+      />
+      <textarea
+        className="w-full border rounded p-2"
+        placeholder="Description"
+        value={desc}
+        onChange={(e) => setDesc(e.target.value)}
+      />
+      <input
+        className="w-full border rounded p-2"
+        placeholder="Asset ID (optional)"
+        value={assetId}
+        onChange={(e) => setAssetId(e.target.value)}
+      />
+      <select
+        className="w-full border rounded p-2"
+        value={priority}
+        onChange={(e) => setPriority(e.target.value)}
+      >
+        <option value="P0">P0 – Emergency</option>
+        <option value="P1">P1 – Urgent</option>
+        <option value="P2">P2 – High</option>
+        <option value="P3">P3 – Normal</option>
+        <option value="P4">P4 – Low</option>
+      </select>
+      <button
+        disabled={saving}
+        onClick={save}
+        className="w-full rounded bg-black text-white p-2"
+      >
+        {saving ? 'Saving...' : 'Create'}
+      </button>
+    </div>
+  );
+}
+

--- a/app/work-orders/page.tsx
+++ b/app/work-orders/page.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+interface WorkOrder {
+  id: number;
+  number: string;
+  title: string;
+  priority: string;
+}
+
+export default function WorkOrdersPage() {
+  const [orders, setOrders] = useState<WorkOrder[]>([]);
+
+  useEffect(() => {
+    fetch('/api/work-orders')
+      .then((res) => res.json())
+      .then((data) => setOrders(Array.isArray(data) ? data : []));
+  }, []);
+
+  return (
+    <div className="p-8 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Work Orders</h1>
+        <Link
+          href="new"
+          className="rounded bg-black px-3 py-1 text-white"
+        >
+          New Work Order
+        </Link>
+      </div>
+      {orders.length === 0 ? (
+        <p>No work orders found.</p>
+      ) : (
+        <ul className="divide-y rounded border">
+          {orders.map((wo) => (
+            <li key={wo.id} className="flex justify-between p-2">
+              <span>
+                {wo.number} – {wo.title}
+              </span>
+              <span className="text-sm text-gray-600">{wo.priority}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a dedicated `/work-orders/new` page to create work orders
- extend work order API with `GET` for listing orders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689897c9484c8323b2a69b4c0bb627eb